### PR TITLE
Add ink in devDependencies and fix example

### DIFF
--- a/examples/ink/example.cljs
+++ b/examples/ink/example.cljs
@@ -12,8 +12,7 @@
                       (setCounter (inc counter)))
                     1000)]
          (fn []
-           (js/clearInterval timer))))
-     [])
+           (js/clearInterval timer)))))
     (react/createElement Text nil counter " tests passed")))
 
 (render (react/createElement Counter))

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "argparse": "^2.0.1",
     "chalk": "^5.0.1",
     "esbuild": "^0.14.49",
+    "ink": "^3.2.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "playwright": "^1.26.1",


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an issue with a clear problem statement: #240

- [ ] This PR provides tests for code additions and changes

- [ ] This PR does not contain bonus changes, i.e. changes not discussed in the linked issue. For those, please submit a new issue + PR.

After submitting this PR, please do not force-push your branch as this makes
collaboration easier. Push as many new commits to your branch, they will be
squashed upon merge.

In React, the [useEffect](https://reactjs.org/docs/hooks-effect.html) hook accepts a list of dependencies as its second argument. When this argument is an empty array, the useEffect hook has no dependencies and runs only once, when the React component mounts.
To re-run the hook every time, we can simply omit the second argument.

I also added `ink` as a dev dependency in the root `package.json`.

