### PR TITLE
Add a simple output-dir option to the cli

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources" "compiler-common"]
  :deps {borkdude/edamame {:mvn/version "1.0.0"}
         babashka/process {:mvn/version "0.1.7"}
-        org.babashka/cli {:mvn/version "0.4.37"}
+        org.babashka/cli {:mvn/version "0.7.51"}
         org.babashka/sci {:mvn/version "0.6.37"}}
  :aliases
  {:dev {}

--- a/src/squint/internal/cli.cljs
+++ b/src/squint/internal/cli.cljs
@@ -10,6 +10,10 @@
 
 (defn compile-files
   [opts files]
+  ;; shouldn't need this if :coerce worked in babashka.cli
+  (when-let [out-dir (:output-dir opts)]
+    (when-not (string? out-dir)
+      (throw (js/Error. "output-dir must be a string"))))
   (if (:help opts)
     (do (println "Usage: squint compile <files> <opts>")
         (println)
@@ -17,7 +21,8 @@
 
 --elide-imports: do not include imports
 --elide-exports: do not include exports
---extension: default extension for JS files"))
+--extension: default extension for JS files
+--output-dir: output directory for JS files"))
     (reduce (fn [prev f]
               (-> (js/Promise.resolve prev)
                   (.then
@@ -91,7 +96,8 @@ Options:
   [{:cmds ["run"]        :fn run :cmds-opts [:file]}
    {:cmds ["compile"]
     :coerce {:elide-exports :boolean
-             :elide-imports :boolean}
+             :elide-imports :boolean
+             :output-dir :string}
     :fn (fn [{:keys [rest-cmds opts]}]
           (compile-files opts rest-cmds))}
    {:cmds ["repl"]       :fn repl/repl}


### PR DESCRIPTION
Fixed #301 

Still missing is the ability for squint to recursively watch a folder of cljs files and output them to a matching folder prepended by the output-dir (which I think is needed for bigger projects), but this is still a step in the right direction IMO.

Let me know if you want any tests or more error handling, I couldn't see any existing tests for the cli and tbh am not sure what they should look like