### PR TITLE
Add `re-pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): ClojureScript syntax to JavaScript compiler
 
+## Unreleased
+
+- Add `re-pattern` (fixes [#396](https://github.com/squint-cljs/squint/issues/396))
+
 ## 0.4.71 (2023-12-02)
 
 - More helpful error from JS when using unresolved symbol in REPL mode

--- a/resources/squint/core.edn
+++ b/resources/squint/core.edn
@@ -135,6 +135,7 @@
   range
   re_find
   re_matches
+  re_pattern
   re_seq
   reduce
   reduce_kv

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -38,7 +38,7 @@ export function _LT_(...xs) {
 }
 
 export function _LT__EQ_(...xs) {
-  return walkArray(xs, (x, y) => x <= y)
+  return walkArray(xs, (x, y) => x <= y);
 }
 
 export function _PLUS_(...xs) {
@@ -845,6 +845,22 @@ export function re_find(re, s) {
   } else {
     throw new TypeError('re-find must match against a string.');
   }
+}
+
+export function re_pattern(s) {
+  if (s instanceof RegExp) {
+    return s;
+  }
+
+  // Allow all flags available in JavaScript
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp#flags
+  const flagMatches = s.match(/^\(\?([dgimsuvy]*)\)/);
+
+  if (flagMatches) {
+    return new RegExp(s.slice(flagMatches[0].length), flagMatches[1]);
+  }
+
+  return new RegExp(s);
 }
 
 export function subvec(arr, start, end) {

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1707,6 +1707,12 @@
   (is (eq (re-find #"(\D+)|(\d+)" "word then number 57")
           (vec (jsv! '(re-find #"(\D+)|(\d+)" "word then number 57"))))))
 
+(deftest re-pattern-test
+  (is (eq #"\d+" (jsv! '(re-pattern "\\d+"))))
+  (is (eq "dgimsvy" (jsv! '(.-flags (re-pattern "(?dgimsvy)foo")))))
+  (is (eq "dgi" (jsv! '(.-flags (re-pattern "(?dgi)foo")))))
+  (is (eq "foo" (jsv! '(.-source (re-pattern "(?dgi)foo"))))))
+
 (deftest js-in-test
   (is (true? (jsv! "(js-in :foo {:foo 1})"))))
 


### PR DESCRIPTION
Add [`re-pattern`](https://github.com/squint-cljs/squint/issues/396).

[CLJS is matching flags](https://github.com/clojure/clojurescript/blob/80acf18ee4ef60768f39589d1f4007895db49ba7/src/main/cljs/cljs/core.cljs#L10411-L10420) that are invalid in JavaScript and is missing some important flags. So, in the spirit of Squint adhering closer to JavaScript itself, I'm matching on the [flags that JavaScript supports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp#flags).
