### PR TITLE
Add `clojure.set` functions`rename`, `project`, and `map-invert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Add `clojure.set` functions `select`, and `rename-keys`
+- Add `clojure.set` functions `select`, `rename-keys`, and `rename`
 - Fix `reduce-kv` with `js/Map` input
 
 ## 0.4.76 (2023-12-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Add `clojure.set` functions `select`, `rename-keys`, `rename`, and `project`
+- Add `clojure.set` functions `select`, `rename-keys`, `rename`, `project`, and `map-invert`
 - Fix `reduce-kv` with `js/Map` input
 
 ## 0.4.76 (2023-12-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Add `clojure.set` functions `select`, `rename-keys`, and `rename`
+- Add `clojure.set` functions `select`, `rename-keys`, `rename`, and `project`
 - Fix `reduce-kv` with `js/Map` input
 
 ## 0.4.76 (2023-12-07)

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,4 +1,4 @@
-import { contains_QMARK_, assoc, get, dissoc, keys, map, set, select_keys, reduce_kv } from './core.js';
+import { contains_QMARK_, assoc, assoc_BANG_, get, dissoc, keys, map, set, select_keys, reduce_kv, empty } from './core.js';
 
 function _intersection2(x, y) {
   if (x.size > y.size) {
@@ -137,5 +137,8 @@ export function project(xrel, ...ks) {
 }
 
 export function map_invert(xmap) {
-  return reduce_kv((m, k, v) => assoc(m, v, k), {}, xmap);
+  if (xmap === undefined) {
+    return {};
+  }
+  return reduce_kv((m, k, v) => assoc_BANG_(m, v, k), empty(xmap), xmap);
 }

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,4 +1,4 @@
-import { contains_QMARK_, assoc, get, dissoc, keys, map, set } from './core.js';
+import { contains_QMARK_, assoc, get, dissoc, keys, map, set, select_keys } from './core.js';
 
 function _intersection2(x, y) {
   if (x.size > y.size) {
@@ -130,4 +130,8 @@ export function rename_keys(map, kmap) {
 
 export function rename(xrel, kmap) {
   return set(map(x => rename_keys(x, kmap), xrel));
+}
+
+export function project(xrel, ...ks) {
+  return set(map(x => select_keys(x, ...ks), xrel));
 }

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,4 +1,4 @@
-import { contains_QMARK_, assoc, get, dissoc, keys } from './core.js';
+import { contains_QMARK_, assoc, get, dissoc, keys, map, set } from './core.js';
 
 function _intersection2(x, y) {
   if (x.size > y.size) {
@@ -126,4 +126,8 @@ export function rename_keys(map, kmap) {
     }
     return m;
   }, dissoc(map, ...ks));
+}
+
+export function rename(xrel, kmap) {
+  return set(map(x => rename_keys(x, kmap), xrel));
 }

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,4 +1,4 @@
-import { contains_QMARK_, assoc, get, dissoc, keys, map, set, select_keys } from './core.js';
+import { contains_QMARK_, assoc, get, dissoc, keys, map, set, select_keys, reduce_kv } from './core.js';
 
 function _intersection2(x, y) {
   if (x.size > y.size) {
@@ -134,4 +134,8 @@ export function rename(xrel, kmap) {
 
 export function project(xrel, ...ks) {
   return set(map(x => select_keys(x, ...ks), xrel));
+}
+
+export function map_invert(xmap) {
+  return reduce_kv((m, k, v) => assoc(m, v, k), {}, xmap);
 }

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,4 +1,4 @@
-import { contains_QMARK_, assoc, assoc_BANG_, get, dissoc, keys, map, set, select_keys, reduce_kv, empty } from './core.js';
+import * as core from './core.js';
 
 function _intersection2(x, y) {
   if (x.size > y.size) {
@@ -118,27 +118,27 @@ export function select(pred, xset) {
 }
 
 export function rename_keys(map, kmap) {
-  const ks = keys(kmap);
+  const ks = core.keys(kmap);
   return ks.reduce((m, k) => {
-    const newKey = get(kmap, k);
-    if (contains_QMARK_(map, k)) {
-      return assoc(m, newKey, get(map, k));
+    const newKey = core.get(kmap, k);
+    if (core.contains_QMARK_(map, k)) {
+      return core.assoc(m, newKey, core.get(map, k));
     }
     return m;
-  }, dissoc(map, ...ks));
+  }, core.dissoc(map, ...ks));
 }
 
 export function rename(xrel, kmap) {
-  return set(map(x => rename_keys(x, kmap), xrel));
+  return core.set(core.map(x => rename_keys(x, kmap), xrel));
 }
 
 export function project(xrel, ...ks) {
-  return set(map(x => select_keys(x, ...ks), xrel));
+  return core.set(core.map(x => core.select_keys(x, ...ks), xrel));
 }
 
 export function map_invert(xmap) {
   if (xmap === undefined) {
     return {};
   }
-  return reduce_kv((m, k, v) => assoc_BANG_(m, v, k), empty(xmap), xmap);
+  return core.reduce_kv((m, k, v) => core.assoc_BANG_(m, v, k), core.empty(xmap), xmap);
 }

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2007,7 +2007,6 @@
        (testing "map-invert"
          (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
                                [(set/map-invert)
-                                (set/map-invert [])
                                 (set/map-invert {})
                                 (set/map-invert {:a 1, :b 2, :c 3})
                                 (set/map-invert (new js/Map [[:a 1] [:d 3]]))]" {:repl true
@@ -2015,9 +2014,8 @@
                  vs (js/eval (wrap-async js))]
            (let [expected [{}
                            {}
-                           {}
                            {1 :a 2 :b 3 :c}
-                           {1 :a 3 :d} #_(set (new js/Map (clj->js [[1 :a 3 :d]])))]
+                           (new js/Map (clj->js [[1 :a] [3 :d]]))]
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1994,7 +1994,7 @@
                         [(set/project #{ {:a 1, :b 2, :c 3} {:a 4, :b 5, :c 6} } [:a :b])
                          (set/project #{ {:a 1 :b 2} {:a 4 :b 5 :c 6} }  [:a :b :c :d])
                          (set/project #{ (new js/Map [[:a 1] [:d 3]]) } [:a])]" {:repl true
-                                                                                              :context :return})
+                                                                                 :context :return})
                  vs (js/eval (wrap-async js))]
            (let [set (fn [& xs] (new js/Set xs))
                  expected [(set #js {:a 1, :b 2} #js {:a 4, :b 5})
@@ -2004,7 +2004,24 @@
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"
                                         (util/inspect expected) (util/inspect s)))))))
-       )
+       (testing "map-invert"
+         (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
+                               [(set/map-invert)
+                                (set/map-invert [])
+                                (set/map-invert {})
+                                (set/map-invert {:a 1, :b 2, :c 3})
+                                #_(set/map-invert (new js/Map [[:a 1] [:d 3]]))]" {:repl true
+                                                                                 :context :return})
+                 vs (js/eval (wrap-async js))]
+           (let [expected [{}
+                           {}
+                           {}
+                           {1 :a 2 :b 3 :c}
+                           #_(set (new js/Map (clj->js [[1 :a 3 :d]])))]
+                 pairs (map vector expected vs)]
+             (doseq [[expected s] pairs]
+               (is (eq expected s) (str "expected vs actual:"
+                                        (util/inspect expected) (util/inspect s))))))))
      (p/finally done))))
 
 (deftest Symbol_iterator-is-destructurable-test

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1958,14 +1958,12 @@
          (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
                  [(set/rename-keys {:a 1, :b 2} {:a :new-a, :b :new-b})
                   (set/rename-keys {:a 1} {:b :new-b})
-                  (set/rename-keys {:a 1 :b 2} {:a :b})
                   (set/rename-keys {:a 1 :b 2}  {:a :b :b :a})
                   (set/rename-keys (new js/Map [[:a {:b 1}]]) {:a {:c 2}})]" {:repl true
                                                                               :context :return})
                  vs (js/eval (wrap-async js))]
            (let [expected [{:new-a 1, :new-b 2}
                            {:a 1}
-                           {:b 1}
                            {:b 1, :a 2}
                            (new js/Map (clj->js [[{:c 2} {:b 1}]]))]
                  pairs (map vector expected vs)]

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1988,7 +1988,23 @@
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"
-                                        (util/inspect expected) (util/inspect s))))))))
+                                        (util/inspect expected) (util/inspect s)))))))
+       (testing "project"
+         (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
+                        [(set/project #{ {:a 1, :b 2, :c 3} {:a 4, :b 5, :c 6} } [:a :b])
+                         (set/project #{ {:a 1 :b 2} {:a 4 :b 5 :c 6} }  [:a :b :c :d])
+                         (set/project #{ (new js/Map [[:a 1] [:d 3]]) } [:a])]" {:repl true
+                                                                                              :context :return})
+                 vs (js/eval (wrap-async js))]
+           (let [set (fn [& xs] (new js/Set xs))
+                 expected [(set #js {:a 1, :b 2} #js {:a 4, :b 5})
+                           (set #js {:a 1, :b 2} #js {:a 4, :b 5, :c 6})
+                           (set (new js/Map (clj->js [[:a 1]])))]
+                 pairs (map vector expected vs)]
+             (doseq [[expected s] pairs]
+               (is (eq expected s) (str "expected vs actual:"
+                                        (util/inspect expected) (util/inspect s)))))))
+       )
      (p/finally done))))
 
 (deftest Symbol_iterator-is-destructurable-test

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2011,7 +2011,7 @@
                                 (set/map-invert {})
                                 (set/map-invert {:a 1, :b 2, :c 3})
                                 #_(set/map-invert (new js/Map [[:a 1] [:d 3]]))]" {:repl true
-                                                                                 :context :return})
+                                                                                   :context :return})
                  vs (js/eval (wrap-async js))]
            (let [expected [{}
                            {}

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2010,14 +2010,14 @@
                                 (set/map-invert [])
                                 (set/map-invert {})
                                 (set/map-invert {:a 1, :b 2, :c 3})
-                                #_(set/map-invert (new js/Map [[:a 1] [:d 3]]))]" {:repl true
+                                (set/map-invert (new js/Map [[:a 1] [:d 3]]))]" {:repl true
                                                                                    :context :return})
                  vs (js/eval (wrap-async js))]
            (let [expected [{}
                            {}
                            {}
                            {1 :a 2 :b 3 :c}
-                           #_(set (new js/Map (clj->js [[1 :a 3 :d]])))]
+                           {1 :a 3 :d} #_(set (new js/Map (clj->js [[1 :a 3 :d]])))]
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1971,6 +1971,23 @@
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"
+                                        (util/inspect expected) (util/inspect s)))))))
+       (testing "rename"
+         (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
+                        [(set/rename #{ {:a 1, :b 2} {:a 3, :b 4} } {:a :new-a, :b :new-b})
+                         (set/rename #{ {:a 1} {:a 2 :b 3} } {:b :new-b})
+                         (set/rename #{ {:a 1 :b 2} {:a 3 :b 4} }  {:a :b :b :a})
+                         (set/rename #{ (new js/Map [[:a {:b 1}]]) } {:a {:c 2}})]" {:repl true
+                                                                                     :context :return})
+                 vs (js/eval (wrap-async js))]
+           (let [set (fn [& xs] (new js/Set xs))
+                 expected [(set #js {:new-a 1, :new-b 2} #js {:new-a 3, :new-b 4})
+                           (set #js {:a 1} #js {:a 2 :new-b 3})
+                           (set #js {:b 1, :a 2} #js {:b 3, :a 4})
+                           (set (new js/Map (clj->js [[{:c 2} {:b 1}]])))]
+                 pairs (map vector expected vs)]
+             (doseq [[expected s] pairs]
+               (is (eq expected s) (str "expected vs actual:"
                                         (util/inspect expected) (util/inspect s))))))))
      (p/finally done))))
 


### PR DESCRIPTION
I amended the PR with two more functions. For map-invert I run into that `reduce-kv` does not handle `Map`s. Should I try to fix it, or do you want to do that, @borkdude?

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
