### PR TITLE
Bubble max set first for `union` and `intersection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Optimization: sort largest set first for `set/union` and `set/intersection`
+- Optimization: sort largest set first for `set/union`, and smallest first for `set/intersection`
 
 ## v0.4.79 (2023-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Optimization: sort largest set first for `set/union` and `set/interesection`
+- Optimization: sort largest set first for `set/union` and `set/intersection`
 
 ## v0.4.79 (2023-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): ClojureScript syntax to JavaScript compiler
 
+## Unreleased
+
+- Optimization: sort largest set first for `set/union` and `set/interesection`
+
 ## v0.4.79 (2023-12-09)
 
 - The `children` function in `tree-seq` may return `nil`

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,8 +1,8 @@
 import * as core from './core.js';
 
 function _bubble_max_key(k, coll) {
-  const max = coll.reduce((max, curr) => k(curr) > k(max) ? curr : max);
-  return [max, ...coll.filter(x => x !== max)];
+  const max = core.apply(core.max_key, k, coll);
+  return [max, ...coll.filter(x => core.identical_QMARK_(x, max))];
 }
 
 function _intersection2(x, y) {

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -5,8 +5,6 @@ function _bubble_max_key(k, coll) {
   return [max, ...coll.filter(x => x !== max)];
 }
 
-export const __testing__bubble_max_key = _bubble_max_key;
-
 function _intersection2(x, y) {
   if (x.size > y.size) {
     const tmp = y;

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -27,7 +27,7 @@ export function intersection(...xs) {
     case 2: return xs[0].length > xs[1].length ? 
       _intersection2(xs[0], xs[1]) :
       _intersection2(xs[1], xs[0]);
-    default: return _bubble_max_key(core.count, xs).reduce(_intersection2);
+    default: return _bubble_max_key((x) => 0 - x.size, xs).reduce(_intersection2);
   }
 }
 
@@ -65,7 +65,7 @@ export function union(...xs) {
     case 2: return xs[0].length > xs[1].length ? 
       _union2(xs[0], xs[1]) : 
       _union2(xs[1], xs[0]);
-    default: return _bubble_max_key(core.count, xs).reduce(_union2);
+    default: return _bubble_max_key((x) => x.size, xs).reduce(_union2);
   }
 }
 

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,9 +1,11 @@
 import * as core from './core.js';
 
 function _bubble_max_key(k, coll) {
-  const max = core.apply(core.max_key, k, coll);
+  const max = core.max_key(k, ...coll);
   return [max, ...coll.filter(x => !core.identical_QMARK_(x, max))];
 }
+
+export const __testing__bubble_max_key = _bubble_max_key;
 
 function _intersection2(x, y) {
   if (x.size > y.size) {

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -1,5 +1,12 @@
 import * as core from './core.js';
 
+function _bubble_max_key(k, coll) {
+  const max = coll.reduce((max, curr) => k(curr) > k(max) ? curr : max);
+  return [max, ...coll.filter(x => x !== max)];
+}
+
+export const __testing__bubble_max_key = _bubble_max_key;
+
 function _intersection2(x, y) {
   if (x.size > y.size) {
     const tmp = y;
@@ -19,8 +26,10 @@ export function intersection(...xs) {
   switch (xs.length) {
     case 0: return null;
     case 1: return xs[0];
-    case 2: return _intersection2(xs[0], xs[1]);
-    default: return xs.reduce(_intersection2);
+    case 2: return xs[0].length > xs[1].length ? 
+      _intersection2(xs[0], xs[1]) :
+      _intersection2(xs[1], xs[0]);
+    default: return _bubble_max_key(core.count, xs).reduce(_intersection2);
   }
 }
 
@@ -55,8 +64,10 @@ export function union(...xs) {
   switch (xs.length) {
     case 0: return null;
     case 1: return xs[0];
-    case 2: return _union2(xs[0], xs[1]);
-    default: return xs.reduce(_union2);
+    case 2: return xs[0].length > xs[1].length ? 
+      _union2(xs[0], xs[1]) : 
+      _union2(xs[1], xs[0]);
+    default: return _bubble_max_key(core.count, xs).reduce(_union2);
   }
 }
 

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -2,7 +2,7 @@ import * as core from './core.js';
 
 function _bubble_max_key(k, coll) {
   const max = core.apply(core.max_key, k, coll);
-  return [max, ...coll.filter(x => core.identical_QMARK_(x, max))];
+  return [max, ...coll.filter(x => !core.identical_QMARK_(x, max))];
 }
 
 function _intersection2(x, y) {

--- a/src/squint/set.js
+++ b/src/squint/set.js
@@ -2,10 +2,8 @@ import * as core from './core.js';
 
 function _bubble_max_key(k, coll) {
   const max = core.max_key(k, ...coll);
-  return [max, ...coll.filter(x => !core.identical_QMARK_(x, max))];
+  return [max, ...coll.filter(x => x !== max)];
 }
-
-export const __testing__bubble_max_key = _bubble_max_key;
 
 function _intersection2(x, y) {
   if (x.size > y.size) {

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2039,7 +2039,7 @@
                                  #{ {:species \"cow\" :personality \"stoic\"}
                                     {:species \"horse\" :personality \"skittish\"} }
                                  {:kind :species})]" {:repl true
-                                                                   :context :return})
+                                                      :context :return})
                  vs (js/eval (wrap-async js))]
            (let [set (fn [& xs] (new js/Set xs))
                  expected [(set #js {:a 1, :b 1} #js {:a 1, :b 2} #js {:a 2, :b 1} #js {:a 2, :b 2})
@@ -2064,7 +2064,7 @@
                                                {:acc-id 1, :user-id 1, :amount 300.45, :type \"saving\"}}
                                              {:type :atype}))
                        [:user-id :acc-id :type :atype])]" {:repl true
-                                     :context :return})
+                                                           :context :return})
                  vs (js/eval (wrap-async js))]
            (let [set (fn [& xs] (new js/Set xs))
                  expected [(set #js {:user-id 1, :acc-id 1, :type "personal", :atype "saving"}
@@ -2073,7 +2073,15 @@
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"
-                                        (util/inspect expected) (util/inspect s))))))))
+                                        (util/inspect expected) (util/inspect s)))))))
+       (testing "bubble-max-key"
+         (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
+                      (set/__testing__bubble_max_key #(:v %) [{:v 1} {:v 2} {:v 3}])"
+                                             {:repl true :context :return})
+                 vs (js/eval (wrap-async js))]
+           (let [expected [#js {:v 3} #js {:v 1} #js {:v 2}]]
+             (is (eq expected vs) (str "expected vs actual:"
+                                       (util/inspect expected) (util/inspect vs)))))))
      (p/finally done))))
 
 (deftest Symbol_iterator-is-destructurable-test

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2073,15 +2073,7 @@
                  pairs (map vector expected vs)]
              (doseq [[expected s] pairs]
                (is (eq expected s) (str "expected vs actual:"
-                                        (util/inspect expected) (util/inspect s)))))))
-       (testing "bubble-max-key"
-         (p/let [js (compiler/compile-string "(ns foo (:require [clojure.set :as set]))
-                      (set/__testing__bubble_max_key #(:v %) [{:v 1} {:v 2} {:v 3}])"
-                                             {:repl true :context :return})
-                 vs (js/eval (wrap-async js))]
-           (let [expected [#js {:v 3} #js {:v 1} #js {:v 2}]]
-             (is (eq expected vs) (str "expected vs actual:"
-                                       (util/inspect expected) (util/inspect vs)))))))
+                                        (util/inspect expected) (util/inspect s))))))))
      (p/finally done))))
 
 (deftest Symbol_iterator-is-destructurable-test


### PR DESCRIPTION
As previously discussed, ported the optimization of doing union and intersection onto the largest set first from ClojureScript's `clojure.set`.

I don't know how to test that it actually is moving the largest set to the top other than testing the utility function itself and exported a special named version of it for this purpose. WDYT?

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
