### PR TITLE
Add mobile-friendly CSS to playground

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,15 +325,59 @@
       }
       compile();
     </script>
+    <style>
+      #main {
+        display: flex;
+        flex-direction: column;
+        max-height: 90dvh;
+
+        @media screen and (min-width: 600px) {
+          overflow: auto;
+          flex-direction: row;
+        }
+      }
+
+      #editor {
+        width: 100%;
+        max-height: 90dvh;
+        max-width: 95dvw;
+        border: 1px solid grey;
+        border-radius: 10px;
+
+        @media screen and (min-width: 600px) {
+          margin-bottom: 10px;
+          overflow: auto;
+          width: 50%;
+        }
+      }
+
+      #sidebar {
+        width: 100%;
+        max-height: 90dvh;
+        max-width: 90dvw;
+        border: 1px solid grey;
+        border-radius: 10px;
+        padding: 10px;
+        margin-top: 10px;
+
+        @media screen and (min-width: 600px) {
+          margin-top: 0px;
+          margin-left: 10px;
+          margin-bottom: 10px;
+          width: 50%;
+          overflow: auto;
+        }
+      }
+    </style>
   </head>
 
   <body>
-    <div style="display: flex; flex-direction: row; max-height: 90dvh; overflow: auto;">
+    <div id="main">
       <div style="position: absolute; right: 0px; top: 0px; margin: 2px">
       <a href="https://gitHub.com/squint-cljs/squint"><img src="https://img.shields.io/github/stars/squint-cljs/squint.svg?style=social&label=Star"></a></div>
-      <div id="editor" style="max-height: 90dvh; overflow: auto; width: 50%; border: 1px solid grey; border-radius: 10px; margin-bottom: 10px;">
+      <div id="editor">
       </div>
-      <div style="width: 50%; max-height: 90dvh; overflow: auto; border: 1px solid grey; border-radius: 10px; margin-left: 10px; padding: 10px; margin-bottom: 10px;">
+      <div id="sidebar">
               <button onClick="compile()">
         Compile!
               </button>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,49 @@
       body {
         max-width: inherit;
       }
+
+      #main {
+        display: flex;
+        flex-direction: column;
+        max-height: 90dvh;
+
+        @media screen and (min-width: 768px) {
+          overflow: auto;
+          flex-direction: row;
+        }
+      }
+
+      #editor {
+        width: 100%;
+        max-height: 90dvh;
+        max-width: calc(100dvw - 20px);
+        border: 1px solid grey;
+        border-radius: 10px;
+        overflow: auto;
+
+        @media screen and (min-width: 768px) {
+          margin-bottom: 10px;
+          width: 50%;
+        }
+      }
+
+      #sidebar {
+        width: 100%;
+        max-height: 90dvh;
+        max-width: calc(100dvw - 40px);
+        border: 1px solid grey;
+        border-radius: 10px;
+        padding: 10px;
+        margin-top: 10px;
+        overflow: auto;
+
+        @media screen and (min-width: 768px) {
+          margin-top: 0px;
+          margin-left: 10px;
+          margin-bottom: 10px;
+          width: 50%;
+        }
+      }
     </style>
 
     <script type="module">
@@ -325,50 +368,6 @@
       }
       compile();
     </script>
-    <style>
-      #main {
-        display: flex;
-        flex-direction: column;
-        max-height: 90dvh;
-
-        @media screen and (min-width: 600px) {
-          overflow: auto;
-          flex-direction: row;
-        }
-      }
-
-      #editor {
-        width: 100%;
-        max-height: 90dvh;
-        max-width: 95dvw;
-        border: 1px solid grey;
-        border-radius: 10px;
-
-        @media screen and (min-width: 600px) {
-          margin-bottom: 10px;
-          overflow: auto;
-          width: 50%;
-        }
-      }
-
-      #sidebar {
-        width: 100%;
-        max-height: 90dvh;
-        max-width: 90dvw;
-        border: 1px solid grey;
-        border-radius: 10px;
-        padding: 10px;
-        margin-top: 10px;
-
-        @media screen and (min-width: 600px) {
-          margin-top: 0px;
-          margin-left: 10px;
-          margin-bottom: 10px;
-          width: 50%;
-          overflow: auto;
-        }
-      }
-    </style>
   </head>
 
   <body>


### PR DESCRIPTION
This PR solves issue #447 by moving some inline styles of the Squint playground into a style tag, and adding media queries for a better layout on mobile. I assume this change does not require a test or changelog addition.

<img width="853" alt="image" src="https://github.com/squint-cljs/squint/assets/20476041/af65e5ab-0562-4b64-8040-ce9bdc4ef282">

---

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
