### PR TITLE
update chokidar to 4.0.1

### DIFF
--- a/examples/game-of-life/package.json
+++ b/examples/game-of-life/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",
-    "chokidar": "^3.5.3",
+    "chokidar": "^4.0.1",
     "vite": "^4.4.11"
   },
   "dependencies": {

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",
-    "chokidar": "^3.5.3",
+    "chokidar": "^4.0.1",
     "vite": "^4.4.11"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "chokidar": "^3.5.3"
+    "chokidar": "^4.0.1"
   },
   "funding": [
     {


### PR DESCRIPTION
- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.

on v4 chokidar reduced it's dependencies from 13 to 1.
this reduces the dependency tree of squint-cljs quite a lot.

I've been using this version in a project with an override for a week now and everything seems to work.

from the [changelog](https://github.com/paulmillr/chokidar?tab=readme-ov-file#upgrading) looks like there is nothing to be changed.
