### PR TITLE
fix: overrides config with cli options

### DIFF
--- a/.clj-kondo/http-kit/http-kit/config.edn
+++ b/.clj-kondo/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,16 @@
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel [{node :node}]
+  (let [[request channel & body] (rest (:children node))]
+    (when-not (and request     channel) (throw (ex-info "No request or channel provided" {})))
+    (when-not (api/token-node? channel) (throw (ex-info "Missing channel argument" {})))
+    (let [new-node
+          (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [channel (api/vector-node [])])
+              request
+              body))]
+
+      {:node new-node})))

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): Light-weight ClojureScript dialect
 
+## v0.8.121 (2024-10-18)
+
+- Fix watcher & compiler not overriding `squint.edn` configurations with command line options.
+
 ## v0.8.120 (2024-10-18)
 
 - Fix watcher not being called

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "squint-cljs",
   "type": "module",
   "sideEffects": false,
-  "version": "0.8.120",
+  "version": "0.8.121",
   "files": [
     "core.js",
     "src/squint/core.js",

--- a/src/squint/internal/cli.cljs
+++ b/src/squint/internal/cli.cljs
@@ -68,9 +68,9 @@
   [opts files]
   (let [cfg @utils/!cfg
         opts (merge cfg opts)
-        paths (:paths cfg)
-        copy-resources (:copy-resources cfg)
-        output-dir (:output-dir cfg ".")
+        paths (:paths opts)
+        copy-resources (:copy-resources opts)
+        output-dir (:output-dir opts ".")
         files (if (empty? files)
                 (files-from-paths paths)
                 files)]
@@ -86,12 +86,13 @@
 --elide-imports: do not include imports
 --elide-exports: do not include exports
 --extension: default extension for JS files
+--paths: source paths to search for cljs/cljc files
 --output-dir: output directory for JS files"))
       (reduce (fn [prev f]
                 (-> (js/Promise.resolve prev)
                     (.then
                      #(do
-                        (if (contains? #{".cljc" ".cljs"} (path/extname f ))
+                        (if (contains? #{".cljc" ".cljs"} (path/extname f))
                           (do (println "[squint] Compiling CLJS file:" f)
                               (compiler/compile-file (assoc opts
                                                             :in-file f
@@ -184,9 +185,9 @@ Options:
 (defn watch [opts]
   (let [cfg @utils/!cfg
         opts (merge cfg opts)
-        paths (:paths cfg)
-        output-dir (:output-dir cfg ".")
-        copy-resources (:copy-resources cfg)]
+        paths (:paths opts)
+        output-dir (:output-dir opts ".")
+        copy-resources (:copy-resources opts)]
     (-> (-> (esm/dynamic-import "chokidar")
             (.catch (fn [err]
                       (js/console.error err))))


### PR DESCRIPTION
Fix watcher & compiler not overriding `squint.edn` configurations with command line options.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
