### PR TITLE
fix: overrides config with cli options on compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): Light-weight ClojureScript dialect
 
+## v0.8.122 (2024-10-18)
+
+- Fix node compiler internal function not overriding `squint.edn` configurations with command line options `--paths`.
+
 ## v0.8.121 (2024-10-18)
 
 - Fix watcher & compiler not overriding `squint.edn` configurations with command line options.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "squint-cljs",
   "type": "module",
   "sideEffects": false,
-  "version": "0.8.121",
+  "version": "0.8.122",
   "files": [
     "core.js",
     "src/squint/core.js",

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -27,6 +27,11 @@
    [squint.internal.protocols :as protocols])
   #?(:cljs (:require-macros [squint.resource :refer [edn-resource]])))
 
+(defn opts+cfg->paths [opts cfg]
+  (-> (into (:paths cfg []) (:paths opts []))
+      seq
+      (or ["." "src"])
+      dedupe))
 
 (defn emit-keyword [expr env]
   ;; emitting string already emits return

--- a/src/squint/compiler/node.cljs
+++ b/src/squint/compiler/node.cljs
@@ -97,7 +97,7 @@
         opts (->opts opts)]
     (-> (compile-string contents opts)
         (.then (fn [{:keys [javascript jsx] :as opts}]
-                 (let [paths (:paths @utils/!cfg ["." "src"])
+                 (let [paths (:paths opts ["." "src"])
                        out-file (path/resolve output-dir
                                               (or out-file
                                                   (str/replace (adjust-file-for-paths in-file paths) #".clj(s|c)$"

--- a/src/squint/compiler/node.cljs
+++ b/src/squint/compiler/node.cljs
@@ -97,7 +97,7 @@
         opts (->opts opts)]
     (-> (compile-string contents opts)
         (.then (fn [{:keys [javascript jsx] :as opts}]
-                 (let [paths (:paths opts ["." "src"])
+                 (let [paths (compiler/opts+cfg->paths opts @utils/!cfg)
                        out-file (path/resolve output-dir
                                               (or out-file
                                                   (str/replace (adjust-file-for-paths in-file paths) #".clj(s|c)$"

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2293,5 +2293,17 @@ new Foo();")
 (deftest issue-537-test
   (is (true? (jsv! "(not (= 1 2))"))))
 
+(deftest opts+cfg->paths-test
+  (is (=  ["." "src"]
+          (squint/opts+cfg->paths {} {})))
+  (is (=  ["src"]
+          (squint/opts+cfg->paths {:paths ["src"]} {})))
+  (is (=  ["src"]
+          (squint/opts+cfg->paths {} {:paths ["src"]})))
+  (is (=  ["src"]
+          (squint/opts+cfg->paths {:paths ["src"]} {:paths ["src"]})))
+  (is (=  ["test" "src"]
+          (squint/opts+cfg->paths {:paths ["src"]} {:paths ["test"]}))))
+
 (defn init []
   (t/run-tests 'squint.compiler-test 'squint.jsx-test 'squint.string-test 'squint.html-test))


### PR DESCRIPTION
I missed this one on the last PR (https://github.com/squint-cljs/squint/pull/566)
The compiler internal function not overriding `squint.edn` configurations with command line options `--paths`.
---
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
