### PR TITLE
Export node-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "./src/squint/core.js": "./src/squint/core.js",
     "./src/squint/set.js": "./src/squint/set.js",
     "./src/squint/string.js": "./src/squint/string.js",
+    "./node-api.js": "./node-api.js",
     "./src/squint/html.js": "./src/squint/html.js"
   }
 }


### PR DESCRIPTION
Hi, while adding macro support to vite-plugin-squint I am getting issues trying to import "node-api.js":

vite-plugin-squint/index.mjs:
import  { compileString }  from "./node_modules/squint-cljs/lib/compiler.node.js"

...

error:
8:32:01 PM [vite] Pre-transform error: The "path" argument must be of type string or an instance of Buffer or URL. Received null
8:32:01 PM [vite] Internal server error: The "path" argument must be of type string or an instance of Buffer or URL. Received null
      at Module.readFileSync (node:fs:446:42)
      at file:///home/daniel/repos/template/node_modules/@w3t-ab/vite-plugin-squint/node_modules/squint-cljs/lib/compiler.sci.js:1165:485
      at file:///home/daniel/repos/template/node_modules/@w3t-ab/vite-plugin-squint/node_modules/squint-cljs/lib/compiler.sci.js:138:316

it works with export in squint-cljs and:

import  { compileString }  from "squint-cljs/node-api.js"

//Daniel