### PR TITLE
fix windowjs example, remove unused modules for gol

### DIFF
--- a/examples/game-of-life/package.json
+++ b/examples/game-of-life/package.json
@@ -1,12 +1,9 @@
-{
+{ "type": "module",
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.1.0",
     "chokidar": "^4.0.1",
-    "vite": "^4.4.11"
+    "vite": "^6.0.1"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "squint-cljs": "latest"
   }
 }

--- a/examples/windowjs/README.md
+++ b/examples/windowjs/README.md
@@ -1,13 +1,9 @@
-# WindowJS
+# canvas animation example
 
-Window.js is an open-source Javascript runtime for desktop graphics programming.
+- Install dependencies:
 
-To run the example in this directory:
+    npm install
 
-```
-$  npx clava hello.cljs && ~/Downloads/windowjs hello.mjs
-```
+- Run `npm run dev` to start compiling `.cljs` -> `.js` and run `vite` server
 
-Replace `~/Downloads/windowsjs` to the location you installed `windowjs`.
-
-See the a [demo tweet](https://twitter.com/borkdude/status/1564560835145617408) here.
+compile with `vite build public`

--- a/examples/windowjs/package.json
+++ b/examples/windowjs/package.json
@@ -1,0 +1,16 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "concurrently": "^9.0.1",
+    "vite": "^6.0.1"
+  },
+  "dependencies": {    
+    "squint-cljs": "latest"
+  },
+  "scripts": {
+    "vite:dev": "vite",
+    "squint:watch": "squint watch --paths src",
+    "dev": "concurrently \"npm run vite:dev\" \"npm run squint:watch\"",
+    "build": "vite build public"
+  }
+}

--- a/examples/windowjs/public/index.html
+++ b/examples/windowjs/public/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf8">    
+  </head>
+  <body>
+    <canvas id="anchor" width="800" height="600"></canvas>
+    <script src="js/index.js" type="module"></script>
+  </body>
+</html>

--- a/examples/windowjs/squint.edn
+++ b/examples/windowjs/squint.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :output-dir "public/js"
+ :extension "js"}

--- a/examples/windowjs/src/index.cljs
+++ b/examples/windowjs/src/index.cljs
@@ -1,8 +1,10 @@
-;; translated from https://github.com/windowjs/windowjs/blob/main/examples/hello.js
+(ns index)
+
+(def canvas (js/document.getElementById "anchor"))
+(def ctx (.getContext canvas "2d"))
 
 (set! js/window.title "Hello")
 
-(def canvas js/window.canvas)
 (def keep-drawing true)
 
 (js/window.addEventListener
@@ -21,20 +23,20 @@
                 (js/requestAnimationFrame draw)))))
 
 (defn draw []
-  (set! canvas.fillStyle "#023047")
-  (canvas.fillRect 0 0 canvas.width canvas.height)
-  (set! canvas.fillStyle "#eb005a")
-  (canvas.fillRect 100 100 200 200)
-  (set! canvas.fillStyle "darkorange")
+  (set! ctx.fillStyle "#023047")
+  (ctx.fillRect 0 0 canvas.width canvas.height)
+  (set! ctx.fillStyle "#eb005a")
+  (ctx.fillRect 100 100 200 200)
+  (set! ctx.fillStyle "darkorange")
   (let [y (/ canvas.height 2)
         w canvas.width
-        t (Math.cos (/ (js/performance.now) 300))
+        t (js/Math.cos (/ (js/performance.now) 300))
         x (+ (/ w 2) (* (/ w 4) t))]
-    (canvas.save)
-    (canvas.translate x y)
-    (canvas.rotate (/ (* t Math/PI) 2))
-    (canvas.fillRect -100 -100 200 200)
-    (canvas.restore))
+    (ctx.save)
+    (ctx.translate x y)
+    (ctx.rotate (/ (* t Math/PI) 2))
+    (ctx.fillRect -100 -100 200 200)
+    (ctx.restore))
   (when keep-drawing
     (js/requestAnimationFrame draw)))
 

--- a/examples/windowjs/vite.config.js
+++ b/examples/windowjs/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  publicDir: 'public', // Set the public folder  
+});


### PR DESCRIPTION
windowjs example wasn't actually working, and game of life example doesn't need react modules