### PR TITLE
Make mapcat be a transducer if no collections are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Unreleased
 
 - Fix [#605](https://github.com/squint-cljs/squint/issues/605): merge command line `--paths` with `squint.edn` config properly
-- Fix [#607](https://github.com/squint-cljs/squint/issues/605): make `mapcat` return a transducer if no collections are provided
+- Fix [#607](https://github.com/squint-cljs/squint/issues/607): make `mapcat` return a transducer if no collections are provided
 
 ## v0.8.132 (2024-12-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Fix [#605](https://github.com/squint-cljs/squint/issues/605): merge command line `--paths` with `squint.edn` config properly
+- Fix [#607](https://github.com/squint-cljs/squint/issues/605): make `mapcat` return a transducer if no collections are provided
 
 ## v0.8.132 (2024-12-29)
 

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -1165,8 +1165,12 @@ concat[IApply__apply] = (colls) => {
 };
 
 export function mapcat(f, ...colls) {
-  const mapped = map(f, ...colls);
-  return concat1(mapped);
+  if (colls.length === 0) {
+    return comp(map(f), cat);
+  } else {
+    const mapped = map(f, ...colls);
+    return concat1(mapped);
+  }
 }
 
 export function identity(x) {

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1269,7 +1269,9 @@
   (is (eq [0 1 2 3 4 5 6 7 8 9] (jsv! '(vec (mapcat identity [[0 1 2 3] [4 5 6] [7 8 9]])))))
   (is (eq ["a" "b" "c" "d"] (jsv! '(vec (mapcat identity {"a" "b" "c" "d"})))))
   (testing "multiple colls"
-    (is (eq ["a" 1 "b" 2] (jsv! '(vec (mapcat list [:a :b :c] [1 2])))))))
+    (is (eq ["a" 1 "b" 2] (jsv! '(vec (mapcat list [:a :b :c] [1 2]))))))
+  (testing "transducer"
+    (is (eq [1 1001 2 1002 3 1003] (into [] (mapcat (fn [x] [x (+ 1000 x)])) [1 2 3])))))
 
 (deftest laziness-test
   (is (eq ["right" "up" "left" "left" "down" "down" "right" "right" "right" "up" "up" "up" "left" "left" "left" "left" "down" "down" "down" "down"]


### PR DESCRIPTION
This resolves issue #607, so that `mapcat` will return a transducer in case no collections are provided:

```clj
(def predicate-keyword-id-map (into {}
                                    (mapcat (fn [[keyword ids]]
                                              (map (fn [id] [id keyword]) ids)))
                                    predicate-id-keyword-map))
```

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
