### PR TITLE
Allow `defclass` without explicit constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): Light-weight ClojureScript dialect
 
+## Unreleased
+
+- Allow `defclass` without an explicit constructor
+
 ## v0.8.137 (2025-02-28)
 
 - Fix [#626](https://github.com/squint-cljs/squint/issues/XXX): Implement `take-last`

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1804,7 +1804,10 @@
                                           state)
                   v (js/eval (wrap-async javascript))]
             (is (= "foo" v)))
-          (p/finally done)))))
+          (p/finally done)))
+    (testing "without constructor"
+      (is (str/includes? (:javascript (squint/compile-string* "(defclass my-el (extends HTMLElement))"))
+                         "class my_el$ extends HTMLElement {\n}")))))
 
 (deftest atom-test
   (is (= 1 (jsv! "(def x (atom 1)) (def y (atom 0)) (add-watch x :foo (fn [k r o n] (swap! y inc))) (reset! x 2) (remove-watch x :foo) (reset! x 3) @y"))))


### PR DESCRIPTION
Current `defclass` emitting code seems to assume there's always a constructor. Not sure if this is a regression, this seems to have worked fine with the version on npm, but running from the repo and trying to compile a defclass form without one results in an AssertionError.

I ran into this working with web components, which don't necessarily have an explicit constructor, but e.g. only a `connectedCallback`.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
