### PR TITLE
Fix early/multiple return statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): Light-weight ClojureScript dialect
 
+## Unreleased
+
+- Fix [#603] prevent unreachable code due to premature `return`
+
 ## v0.8.137 (2025-02-28)
 
 - Fix [#626](https://github.com/squint-cljs/squint/issues/XXX): Implement `take-last`

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -229,8 +229,7 @@
                                       'js-?? "??"}]
                    (str/join (str " " (or (substitutions operator)
                                           operator) " ")
-                             (map wrap-parens (emit-args env args))))
-                 ))
+                             (map wrap-parens (emit-args env args))))))
        (emit-return enc-env)
        (cond-> bool? (bool-expr))))))
 

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2388,5 +2388,13 @@ new Foo();")
 (deftest issue-599-test
   (is (eq [1 2 3] (jsv! "(def f #(apply vector %&)) (f 1 2 3)"))))
 
+(deftest multiple-forms-in-return-context-test
+  (testing "only the final form gets a `return` prepended"
+    (is (str/includes?
+         (squint/compile-string
+          "(foo) (bar)" {:repl true
+                         :context :return})
+         "foo();\nbar();\nreturn baz();"))))
+
 (defn init []
   (t/run-tests 'squint.compiler-test 'squint.jsx-test 'squint.string-test 'squint.html-test))


### PR DESCRIPTION
When emitting multiple forms in a `:return` context, only the final expression should be returned

Fixes #603

Opening this as a draft for discussion, as I realize there's a tricky problem here.

The basic idea is pretty simple, in `:context :return` only the final expression should get a `return ...;`. But for that you need to know if you're at the final expression, which means looking ahead one expression. But if the expression is a `ns` or `require` then it can influence the reading of the next expression (because `*aliases*`). So you can't really read the next expression until the previous one has been emitted.

@borkdude is it possible with edamame to see if you're at EOF without yet trying to read a next expression? Any other ideas for how to solve this?

----

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
