### PR TITLE
Fix issue #640: don't emit anonymous function if it is a statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Squint](https://github.com/squint-cljs/squint): Light-weight ClojureScript dialect
 
+## Unreleased
+
+- Fix [#640](https://github.com/squint-cljs/squint/issues/640): don't emit anonymous function if it is a statement
+
 ## v0.8.141 (2025-03-10)
 
 - Fix [#602](https://github.com/squint-cljs/squint/issues/602): support hiccup-style shorthand for id and class attributes in `#jsx` and `#html`

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -852,30 +852,33 @@ break;}" body)
                expr)
         signature (first expr)
         arrow? (or (:arrow env) (:=> (meta signature)))
-        env (assoc env :arrow arrow?)]
-    (if (some #(= '& %) signature)
-      ;; this still needs macro-expansion, see issue #599
-      (let [new-f (with-meta
-                    (cons 'fn expr)
-                    (meta expr))]
-        (emit new-f env))
-      (-> (if name
-            (let [body (rest expr)]
-              (str (when *async*
-                     "async ") "function"
-                   ;; TODO: why is this duplicated here and in emit-function?
-                   (when (:gen env)
-                     "*")
-                   " "
-                   (munge name) " "
-                   (emit-function env name signature body true)))
-            (let [body (rest expr)]
-              (str (emit-function env nil signature body))))
-          (cond-> (and
-                   (not (:squint.internal.fn/def opts))
-                   (not arrow?)
-                   (= :expr (:context env))) (wrap-parens))
-          (emit-return env)))))
+        env (assoc env :arrow arrow?)
+        omit? (and (= :statement (:context env))
+                   (nil? name))]
+    (when-not omit?
+      (if (some #(= '& %) signature)
+        ;; this still needs macro-expansion, see issue #599
+        (let [new-f (with-meta
+                      (cons 'fn expr)
+                      (meta expr))]
+          (emit new-f env))
+        (-> (if name
+              (let [body (rest expr)]
+                (str (when *async*
+                       "async ") "function"
+                     ;; TODO: why is this duplicated here and in emit-function?
+                     (when (:gen env)
+                       "*")
+                     " "
+                     (munge name) " "
+                     (emit-function env name signature body true)))
+              (let [body (rest expr)]
+                (str (emit-function env nil signature body))))
+            (cond-> (and
+                     (not (:squint.internal.fn/def opts))
+                     (not arrow?)
+                     (= :expr (:context env))) (wrap-parens))
+            (emit-return env))))))
 
 (defmethod emit-special 'fn* [_type env [_fn & sigs :as expr]]
   (let [m (meta expr)

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2388,6 +2388,9 @@ new Foo();")
   (is (= 0.5 (jsv! "(/ 2)")))
   (is (= 0.5 (jsv! "(let [f (fn [] (/ 2))] (f))"))))
 
+(deftest fn-statement-test
+  (is (= 4 (jsv! "(do (fn [] 119) 4)"))))
+
 (deftest issue-599-test
   (is (eq [1 2 3] (jsv! "(def f #(apply vector %&)) (f 1 2 3)"))))
 


### PR DESCRIPTION
This fixes issue #640 by not emitting JavaScript code for anonymous functions that are statements.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
