### PR TITLE
Fix issue #643: Support lexicographic compare of arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Fix [#640](https://github.com/squint-cljs/squint/issues/640): don't emit anonymous function if it is a statement
+- Fix [#643](https://github.com/squint-cljs/squint/issues/643): Support lexicographic compare of arrays
 
 ## v0.8.141 (2025-03-10)
 

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -2279,6 +2279,22 @@ export function compare(x, y) {
         return -1;
       }
       return 1;
+    } else if (Array.isArray(x) && Array.isArray(y)) {
+      // Implemented like `APersistentVector.compareTo`.
+      if (x.length < y.length) {
+        return -1;
+      } else if (x.length > y.length) {
+        return 1;
+      } else {
+        for (let i = 0; i < x.length; i++) {
+          let c = compare(x[i], y[i]);
+          if (c != 0) {
+            return c;
+          }
+        }
+        return 0;
+      }
+      
     } else {
       throw new Error(`comparing ${tx} to ${ty}`);
     }

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1559,9 +1559,38 @@
   (is (eq (sort nil) (jsv! '(sort nil))))
   (is (eq (sort "zoob") (jsv! '(sort "zoob")))))
 
+(deftest compare-test
+  (is (eq 0 (jsv! '(compare nil nil))))
+  (is (eq -1 (jsv! '(compare nil 3))))
+  (is (eq 1 (jsv! '(compare 3 nil))))
+  (is (eq 0 (jsv! '(compare 3 3))))
+  (is (eq -1 (jsv! '(compare 3 4))))
+  (is (eq 1 (jsv! '(compare 4 3))))
+  (is (eq 0 (jsv! '(compare "abc" "abc"))))
+  (is (eq -1 (jsv! '(compare "abc" "xyz"))))
+  (is (eq 1 (jsv! '(compare "xyz" "abc"))))
+  (is (eq 1 (jsv! '(compare ["xyz"] ["abc"]))))
+  (is (eq -1 (jsv! '(compare ["xyz"] ["abc" 3]))))
+  (is (eq 1 (jsv! '(compare ["abc" 3] ["xyz"]))))
+  (is (eq -1 (jsv! '(compare ["abc"] ["xyz"]))))
+  (is (eq -1 (jsv! '(compare ["abc" 3] ["xyz" 2]))))
+  (is (eq -1 (jsv! '(compare ["abc" 2] ["xyz" 3]))))
+  (is (eq 1 (jsv! '(compare ["xyz" 2] ["abc" 3]))))
+  (is (eq 1 (jsv! '(compare ["xyz" 3] ["abc" 2]))))
+  (is (eq -1 (jsv! '(compare ["xyz" 2] ["xyz" 3]))))
+  (is (eq 0 (jsv! '(compare ["xyz" 2] ["xyz" 2]))))
+  (is (eq 1 (jsv! '(compare ["xyz" 3] ["xyz" 2])))))
+
 (deftest sort-by-test
   (is (eq (sort-by count ["aaa" "bb" "c"]) (jsv! '(sort-by count ["aaa" "bb" "c"]))))
-  (is (eq (sort-by - [55445, 54093, 57505]) (jsv! '(sort-by - [55445, 54093, 57505])))))
+  (is (eq (sort-by - [55445, 54093, 57505]) (jsv! '(sort-by - [55445, 54093, 57505]))))
+  (is (eq [{:entity 100 :attribute "b"}
+           {:entity 100 :attribute "c"}
+           {:entity 119 :attribute "a"}]
+          (jsv! '(sort-by (juxt :entity :attribute)
+                          [{:entity 119 :attribute "a"}
+                           {:entity 100 :attribute "c"}
+                           {:entity 100 :attribute "b"}])))))
 
 (deftest shuffle-test
   (let [shuffled (jsv! '(shuffle [1 2 3 4]))]


### PR DESCRIPTION
This issue fixes issue #643 to support lexicographic `compare` of arrays, which is useful with `sort-by`.

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
