### PR TITLE
test:node: remove dummy invocation of npx

### DIFF
--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -64,7 +64,6 @@
     (assert (not (fs/exists? "test-project/lib/bar.json")))))
 
 (defn test-run [_]
-  (shell {:continue true} "npx") ;; dummy invocation
   (let [dir "test-project"
         out (:out (shell {:dir dir :out :string} (fs/which "npx") "squint" "run" "script.cljs"))]
     (assert (str/includes? out "dude"))))


### PR DESCRIPTION
This seems to work fine on CI, but when `bb test:node` is run locally, the dummy invocation of `npx` brings up an interactive terminal.

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
